### PR TITLE
Fixes for Tasks 64954 and 64982

### DIFF
--- a/.bluemix/description.md
+++ b/.bluemix/description.md
@@ -7,13 +7,15 @@ Your project includes GitHub for both source control and work planning and manag
 ### About the Upgrade Process
 When you create this toolchain, it is preconfigured with GitHub for source control, Delivery Pipeline for building and deployment, and the Eclipse Orion Web IDE for code editing. You can add more tools to the toolchain as needed.
 
-After you create the toolchain, use your DevOps Services project for reference purposes only. If you need to use the project for production purposes, delete this toolchain.
+After you create the toolchain, use your DevOps Services project for reference purposes only. 
 
 To get started, click **Create**.
 
 ### More Info
 
+[Tutorial on upgrading your project](http://ibm.biz/DevOpsProjectUpgradeTutorial)
+
 [Getting started with Continuous Delivery](https://console.ng.bluemix.net/docs/services/ContinuousDelivery/index.html)
 
- [Bluemix Continuous Delivery is now live](https://www.ibm.com/blogs/bluemix/2016/11/bluemix-continuous-delivery-is-now-live/)
+[Bluemix Continuous Delivery is now live](https://www.ibm.com/blogs/bluemix/2016/11/bluemix-continuous-delivery-is-now-live/)
 


### PR DESCRIPTION
Task 64954 - Add a link to the tutorial in the deploy UI page shown as part of upgrading v1
Task 64982 - Remove reference to deleting tool chain from template documentation