### PR TITLE
Changes related to Authorizing GitHub

### DIFF
--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -39,6 +39,6 @@
        }
     ],
     "actions": {
-		"update": []
+		"create": []
     }    
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -37,7 +37,11 @@
       	"type": "string",
       	"key": "existing_repo_url",
       	"readonly": true
-       }
+       }, {  
+	"description": "Enable GitHub's Issues page for lightweight issue tracking.",       
+       	"type": "boolean",
+	"key": "has_issues"   
+        }
     ],
     "actions": {        
         "update": ["repo_url"]

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -35,7 +35,8 @@
       	"readonly": true
        }, {           
        	"type": "boolean",
-       	"key": "has_issues"    
+       	"key": "has_issues",
+	"readonly": true       
        }
     ]   
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -18,8 +18,7 @@
       "has_issues": {
 		 "title": "Enable GitHub Issues",
 		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
-		 "type": "boolean",
-		 "default": true
+		 "type": "boolean"
       }  
     },
     "form": [        

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -15,6 +15,10 @@
     },
     "form": [        
       {
+        "type": "validator",
+        "url": "/devops/setup/bm-helper/github_helper.html"
+      },  
+      {
         "description": "Repository Type",
         "type": "string",
         "key": "repo_type",

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -14,12 +14,7 @@
       "type": {
         "type": "string",
         "default": "Existing"
-      },
-      "has_issues": {
-		 "title": "Enable GitHub Issues",
-		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
-		 "type": "boolean"
-      }  
+      } 
     },
     "form": [        
       {
@@ -36,13 +31,9 @@
       	"type": "string",
       	"key": "existing_repo_url",
       	"readonly": true
-       }, {  
-	"description": "Enable GitHub's Issues page for lightweight issue tracking.",       
-       	"type": "boolean",
-	"key": "has_issues"   
-        }
+       }
     ],
     "actions": {        
-        "update": ["repo_url","has_issues"]
+        "update": ["repo_url"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -11,7 +11,13 @@
       "type": {
         "type": "string",
         "default": "Existing"
-      }
+      },
+      "has_issues": {
+		 "title": "Enable GitHub Issues",
+		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
+		 "type": "boolean",
+		 "default": true
+	  }  
     },
     "form": [        
       {
@@ -28,6 +34,12 @@
       "type": "string",
       "key": "repo_url",
       "readonly": "true"
-     }
-    ]
+       }, {           
+       "type": "boolean",
+       "key": "has_issues"    
+       }
+    ],
+    "actions": {
+		"update": ["repo_url", "has_issues"]
+    }    
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -40,6 +40,6 @@
        }
     ],
     "actions": {
-		"update": ["repo_url", "has_issues"]
+		"update": ["has_issues"]
     }    
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -15,8 +15,7 @@
       "has_issues": {
 		 "title": "Enable GitHub Issues",
 		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
-		 "type": "boolean",
-		 "default": true
+		 "type": "boolean"
 	  }  
     },
     "form": [        

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -37,8 +37,5 @@
        	"type": "boolean",
        	"key": "has_issues"    
        }
-    ],
-    "actions": {
-		"create": []
-    }    
+    ]   
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -8,7 +8,7 @@
       "repo_url": {
           "type": "string"
       },
-      "repo_type": {
+      "type": {
         "type": "string",
         "default": "Existing"
       }
@@ -21,7 +21,7 @@
       {
         "description": "Repository Type",
         "type": "string",
-        "key": "repo_type",
+        "key": "type",
         "readonly": "true"
        }, {
       "description": "Link to the specified source repository URL",

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -37,6 +37,6 @@
        }
     ],
     "actions": {        
-        "update": ["has_issues"]
+        "create": ["repo_url"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -37,6 +37,6 @@
        }
     ],
     "actions": {        
-        "update": ["repo_url", "has_issues"]
+        "update": ["has_issues"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -13,11 +13,7 @@
         "default": "Existing"
       }
     },
-    "form": [
-      {
-        "type": "validator",
-        "url": "/devops/setup/bm-helper/github_helper.html"
-      },  
+    "form": [        
       {
         "description": "Repository Type",
         "type": "string",

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -11,7 +11,13 @@
       "type": {
         "type": "string",
         "default": "Existing"
-      } 
+      },
+      "has_issues": {
+		 "title": "Enable GitHub Issues",
+		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
+		 "type": "boolean",
+		 "default": true
+      }  
     },
     "form": [        
       {
@@ -31,6 +37,6 @@
        }
     ],
     "actions": {        
-        "update":["repo_url"]    
+        "update": ["repo_url", "has_issues"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -29,5 +29,8 @@
       	"key": "repo_url",
       	"readonly": true
        }
-    ]   
+    ],
+    "actions": {        
+        "update":["repo_url"]    
+    }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -27,12 +27,12 @@
         "description": "Repository Type",
         "type": "string",
         "key": "type",
-        "readonly": "true"
+        "readonly": true
        }, {
       	"description": "Link to the specified source repository URL",
       	"type": "string",
       	"key": "repo_url",
-      	"readonly": "true"
+      	"readonly": true
        }, {           
        	"type": "boolean",
        	"key": "has_issues"    

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -13,10 +13,9 @@
         "default": "Existing"
       },
       "has_issues": {
-		 "title": "Enable GitHub Issues",
-		 "description": "Enable GitHub's Issues page for lightweight issue tracking.",
-		 "type": "boolean"
-	  }  
+	 "type": "boolean",
+	 "default": true
+      }  
     },
     "form": [        
       {
@@ -33,7 +32,8 @@
       	"type": "string",
       	"key": "repo_url",
       	"readonly": true
-       }, {           
+       }, {  
+	"description": "Enable GitHub's Issues page for lightweight issue tracking.",       
        	"type": "boolean",
        	"key": "has_issues",
 	"readonly": true       

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -43,6 +43,6 @@
         }
     ],
     "actions": {        
-        "update": ["repo_url"]
+        "update": ["repo_url","has_issues"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -14,7 +14,13 @@
       "type": {
         "type": "string",
         "default": "Existing"
-      } 
+      },
+      "has_issues": {
+		"title": "Enable GitHub Issues",
+		"description": "Enable GitHub's Issues page for lightweight issue tracking.",
+		"type": "boolean",
+		"default": true
+	  }
     },
     "form": [        
       {
@@ -34,6 +40,6 @@
        }
     ],
     "actions": {        
-        "update": ["repo_url"]
+        "update": ["repo_url","has_issues"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -8,6 +8,9 @@
       "repo_url": {
           "type": "string"
       },
+      "existing_repo_url": {
+          "type": "string"        
+      },    
       "type": {
         "type": "string",
         "default": "Existing"
@@ -32,11 +35,11 @@
        }, {
       	"description": "Link to the specified source repository URL",
       	"type": "string",
-      	"key": "repo_url",
+      	"key": "existing_repo_url",
       	"readonly": true
        }
     ],
     "actions": {        
-        "create": ["repo_url"]
+        "update": ["repo_url"]
     }
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -11,11 +11,7 @@
       "type": {
         "type": "string",
         "default": "Existing"
-      },
-      "has_issues": {
-	 "type": "boolean",
-	 "default": true
-      }  
+      } 
     },
     "form": [        
       {
@@ -32,11 +28,6 @@
       	"type": "string",
       	"key": "repo_url",
       	"readonly": true
-       }, {  
-	"description": "Enable GitHub's Issues page for lightweight issue tracking.",       
-       	"type": "boolean",
-       	"key": "has_issues",
-	"readonly": true       
        }
     ]   
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -29,16 +29,16 @@
         "key": "type",
         "readonly": "true"
        }, {
-      "description": "Link to the specified source repository URL",
-      "type": "string",
-      "key": "repo_url",
-      "readonly": "true"
+      	"description": "Link to the specified source repository URL",
+      	"type": "string",
+      	"key": "repo_url",
+      	"readonly": "true"
        }, {           
-       "type": "boolean",
-       "key": "has_issues"    
+       	"type": "boolean",
+       	"key": "has_issues"    
        }
     ],
     "actions": {
-		"update": ["has_issues"]
+		"update": []
     }    
 }

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -15,6 +15,10 @@
     },
     "form": [
       {
+        "type": "validator",
+        "url": "/devops/setup/bm-helper/github_helper.html"
+      },  
+      {
         "description": "Repository Type",
         "type": "string",
         "key": "repo_type",

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: true
+    has_issues: "{{github.parameters.has_issues}}"
   hidden: [form, description]       
 
 # Pipelines
@@ -65,3 +65,5 @@ github:
   parameters:
     repo_url: "{{projectRepoUrl}}"
     existing_repo_url: "{{projectRepoUrl}}"
+    has_issues: true
+    

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: "{{github.parameters.has_issues}}"
+    has_issues: {{github.parameters.has_issues}}
   hidden: [form, description]       
 
 # Pipelines

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: "{{github.parameters.has_issues}}"
+    has_issues: true
   hidden: [form, description]       
 
 # Pipelines
@@ -64,6 +64,4 @@ github:
   service-category: githubpublic
   parameters:
     repo_url: "{{projectRepoUrl}}"
-    existing_repo_url: "{{projectRepoUrl}}"
-    has_issues: true
-    
+    existing_repo_url: "{{projectRepoUrl}}"    

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -64,3 +64,4 @@ github:
   service-category: githubpublic
   parameters:
     repo_url: "{{projectRepoUrl}}"
+    existing_repo_url: "{{projectRepoUrl}}"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -13,7 +13,7 @@ description: "
   "
 image: data:image/svg+xml;base64,$file(toolchain.svg,base64)
 required: 
- - deploy
+ - github
  - repo
  
 toolchain:

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: {{github.parameters.has_issues}}
+    has_issues: true
   hidden: [form, description]       
 
 # Pipelines
@@ -64,4 +64,3 @@ github:
   service-category: githubpublic
   parameters:
     repo_url: "{{projectRepoUrl}}"
-    has_issues: true

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: true
+    has_issues: {{github.parameters.has_issues}}
   hidden: [form, description]       
 
 # Pipelines
@@ -64,3 +64,4 @@ github:
   service-category: githubpublic
   parameters:
     repo_url: "{{projectRepoUrl}}"
+    has_issues: true

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -12,16 +12,17 @@ description: "
   [Blog: Bluemix Continuous Delivery](https://www.ibm.com/blogs/bluemix/2016/11/bluemix-continuous-delivery-is-now-live/)\n
   "
 image: data:image/svg+xml;base64,$file(toolchain.svg,base64)
+required: 
+ - deploy
+ - repo
+ 
 toolchain:
   name: "{{projectName}}"
   generator: migration-engine
   template:
     v1-projectId: "{{projectId}}"
     scheduledDate: "{{scheduledDate}}"
-  required: 
-     - deploy
-     - repo
-
+    
 # Github repos
 repo:
   service_id: githubpublic

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -30,7 +30,7 @@ repo:
     repo_name: "{{projectName}}"
     repo_url: "{{projectRepoUrl}}"
     type: link
-    has_issues: {{github.parameters.has_issues}}
+    has_issues: "{{github.parameters.has_issues}}"
   hidden: [form, description]       
 
 # Pipelines


### PR DESCRIPTION
The changes include
1) Adding the validator for authorizing github.
2) Adding the update action without which the github tile gives an error .
Also added has_issues property because the update action needs it.
3) Adding existing_repo_url to the form because the validate action is making the repo_url field editable and showing all the existing repositories. As we want to have a readonly field which shows the existing repo, we are achieving this by having a duplicate field existing_repo_url which shows the repository url and hides the repo_url filed which the validator makes editable.
4) Moved required field in toolchain.yaml to the top. Otherwise this field is ignored.