### PR TITLE
Add support for Github Enterprise authorization

### DIFF
--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -6,13 +6,16 @@
     "type": "object",
     "properties": {
       "repo_url": {
-          "type": "string"
+          "type": "string",        
+          "title": "Source repository URL"
       },
       "existing_repo_url": {
-          "type": "string"        
+          "type": "string",        
+          "title": "Source repository URL"        
       },
       "type": {
         "type": "string",
+	"title": "Repository type",
         "default": "Existing"
       },
       "has_issues": {
@@ -28,12 +31,11 @@
         "url": "/devops/setup/bm-helper/github_helper.html"
       },  
       {
-        "description": "Repository Type",
         "type": "string",
         "key": "type",
         "readonly": "true"
        }, {
-      "description": "Link to the specified source repository URL",
+      "description": "The repository that your toolchain will link to.",
       "type": "string",
       "key": "existing_repo_url",
       "readonly": "true"

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -11,7 +11,7 @@
       "existing_repo_url": {
           "type": "string"        
       },
-      "repo_type": {
+      "type": {
         "type": "string",
         "default": "Existing"
       },
@@ -30,7 +30,7 @@
       {
         "description": "Repository Type",
         "type": "string",
-        "key": "repo_type",
+        "key": "type",
         "readonly": "true"
        }, {
       "description": "Link to the specified source repository URL",

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -8,12 +8,25 @@
       "repo_url": {
           "type": "string"
       },
+      "existing_repo_url": {
+          "type": "string"        
+      },
       "repo_type": {
         "type": "string",
         "default": "Existing"
-      }
+      },
+      "has_issues": {
+		"title": "Enable GitHub Enterprise Issues",
+		"description": "Enable GitHub Enterprise Issues page for lightweight issue tracking.",
+		"type": "boolean",
+		"default": true
+	  }
     },
     "form": [
+      {
+        "type": "validator",
+        "url": "/devops/setup/bm-helper/github_helper.html"
+      },  
       {
         "description": "Repository Type",
         "type": "string",
@@ -22,8 +35,11 @@
        }, {
       "description": "Link to the specified source repository URL",
       "type": "string",
-      "key": "repo_url",
+      "key": "existing_repo_url",
       "readonly": "true"
      }
-    ]
+    ],
+    "actions": {        
+        "update": ["repo_url","has_issues"]
+    }
 }

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -12,15 +12,16 @@ description: "
   [Bluemix Continuous Delivery](https://www.ibm.com/blogs/bluemix/2016/11/bluemix-continuous-delivery-is-now-live/)\n
   "
 image: data:image/svg+xml;base64,$file(toolchain.svg,base64)
+required: 
+ - github
+ - repo
+ 
 toolchain:
   name: "{{projectName}}"
   generator: migration-engine
   template:
     v1-projectId: "{{projectId}}"
     scheduledDate: "{{scheduledDate}}"
-  required: 
-     - deploy
-     - repo
 
 # Github repos
 repo:
@@ -63,3 +64,4 @@ github:
   service-category: github_integrated
   parameters:
     repo_url: "{{projectRepoUrl}}"
+    existing_repo_url: "{{projectRepoUrl}}"


### PR DESCRIPTION
The changes include
1) Adding the validator for authorizing GHE.
2) Adding the update action without which the GHE tile gives an error .
Also added has_issues property because the update action needs it.
3) Adding existing_repo_url to the form because the validate action is making the repo_url field editable and showing all the existing repositories. As we want to have a readonly field which shows the existing repo, we are achieving this by having a duplicate field existing_repo_url which shows the repository url and hides the repo_url filed which the validator makes editable.
4) Moved required field in toolchain.yaml to the top. Otherwise this field is ignored.