### PR TITLE
Add v1 pipeline stage count info to toolchain template

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -23,6 +23,7 @@ toolchain:
   template:
     v1-projectId: '{{projectId}}'
     scheduledDate: '{{scheduledDate}}'
+    v1-pipelineStages: '{{v1PipelineStages}}'
     getting_started: >-
       This toolchain was created from your [DevOps Services
       project]({{projectUrl}}). Before you start to use the toolchain, complete


### PR DESCRIPTION
This info will be used by the migration engine which listens to toolchain creation events and verifies whether the number of v2 pipeline stages are same as v1 pipeline stages.